### PR TITLE
Install rbtools into a virtualenv when it isn't already available.

### DIFF
--- a/src/main/java/org/reviewboard/rbjenkins/steps/ReviewBoardSetup.java
+++ b/src/main/java/org/reviewboard/rbjenkins/steps/ReviewBoardSetup.java
@@ -1,5 +1,6 @@
 package org.reviewboard.rbjenkins.steps;
 
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -11,6 +12,7 @@ import hudson.util.FormValidation;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.List;
 import jenkins.model.GlobalConfiguration;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
@@ -28,8 +30,7 @@ import org.reviewboard.rbjenkins.config.ReviewBoardServerConfiguration;
  * the patch from Review Board for the given review request.
  */
 public class ReviewBoardSetup extends Builder implements SimpleBuildStep {
-    private static final String RBT_INSTALL = "pip install --user rbtools";
-    private static final String RBT_COMMAND = "rbt patch --api-token %s --server %s --diff-revision %d %s%d";
+    private static final String VENV_DIR = ".rbtools-venv";
 
     private boolean downloadOnly = false;
     private boolean installRBTools = true;
@@ -69,7 +70,7 @@ public class ReviewBoardSetup extends Builder implements SimpleBuildStep {
         try {
             reviewRequest = ReviewBoardUtils.parseReviewRequestFromParameters(run.getActions(ParametersAction.class));
         } catch (MalformedURLException e) {
-            listener.error("URL provided in REVIEWBOARD_SERVER is not a " + "valid URL.");
+            listener.error("URL provided in REVIEWBOARD_SERVER is not a valid URL.");
             run.setResult(Result.FAILURE);
             return;
         }
@@ -79,10 +80,9 @@ public class ReviewBoardSetup extends Builder implements SimpleBuildStep {
                 || reviewRequest.getRevision() == -1
                 || reviewRequest.getStatusUpdateId() == -1
                 || reviewRequest.getServerURL() == null) {
-            listener.error("REVIEWBOARD_REVIEW_ID, " + "REVIEWBOARD_DIFF_REVISION or "
-                    + "REVIEWBOARD_STATUS_UPDATE_ID, or "
-                    + "REVIEWBOARD_SERVER not provided in "
-                    + "parameters");
+            listener.error("REVIEWBOARD_REVIEW_ID, REVIEWBOARD_DIFF_REVISION or "
+                    + "REVIEWBOARD_STATUS_UPDATE_ID, or REVIEWBOARD_SERVER not "
+                    + "provided in parameters");
             run.setResult(Result.FAILURE);
             return;
         }
@@ -105,38 +105,76 @@ public class ReviewBoardSetup extends Builder implements SimpleBuildStep {
             return;
         }
 
-        String downloadOnlyFile = "";
+        final EnvVars env = run.getEnvironment(listener);
+
+        // Determine which rbt executable to use. If rbtools is not already
+        // available on the PATH, install it into a virtualenv in the workspace
+        // and use the rbt from there.
+        final ArrayList<List<String>> commands = new ArrayList<List<String>>();
+        String rbtExecutable = "rbt";
+
+        if (installRBTools && !isRBToolsAvailable(launcher, workspace, env, rbtExecutable)) {
+            // Python virtualenvs use a different layout on Windows. The
+            // executables live in "Scripts" with a ".exe" suffix rather than
+            // in "bin". Use the agent's OS to pick the right paths.
+            final boolean isUnix = launcher.isUnix();
+            final String binDir = isUnix ? "bin" : "Scripts";
+            final String exeSuffix = isUnix ? "" : ".exe";
+
+            final FilePath venvDir = workspace.child(VENV_DIR);
+            final String venvRbt =
+                    venvDir.child(binDir).child("rbt" + exeSuffix).getRemote();
+            rbtExecutable = venvRbt;
+
+            if (!isRBToolsAvailable(launcher, workspace, env, venvRbt)) {
+                // No existing virtualenv to reuse, so create one and install
+                // rbtools into it.
+                final String venvPip =
+                        venvDir.child(binDir).child("pip" + exeSuffix).getRemote();
+                commands.add(List.of("python3", "-m", "venv", venvDir.getRemote()));
+                commands.add(List.of(venvPip, "install", "rbtools"));
+            }
+        }
+
+        // Construct the command to use rbtools to apply the patch. Each
+        // argument is passed separately so that values such as the server URL
+        // are never split on whitespace.
+        final List<String> rbtCommand = new ArrayList<String>();
+        rbtCommand.add(rbtExecutable);
+        rbtCommand.add("patch");
+        rbtCommand.add("--api-token");
+        final int apiTokenIndex = rbtCommand.size();
+        rbtCommand.add(serverConfig.getReviewBoardAPIToken());
+        rbtCommand.add("--server");
+        rbtCommand.add(serverConfig.getReviewBoardURL());
+        rbtCommand.add("--diff-revision");
+        rbtCommand.add(Integer.toString(reviewRequest.getRevision()));
         if (downloadOnly) {
-            downloadOnlyFile = "--write patch.diff ";
+            rbtCommand.add("--write");
+            rbtCommand.add("patch.diff");
         }
+        rbtCommand.add(Integer.toString(reviewRequest.getReviewId()));
+        commands.add(rbtCommand);
 
-        // Construct commands to install and use rbtools.
-        final String rbtCommand = String.format(
-                RBT_COMMAND,
-                serverConfig.getReviewBoardAPIToken(),
-                serverConfig.getReviewBoardURL(),
-                reviewRequest.getRevision(),
-                downloadOnlyFile,
-                reviewRequest.getReviewId());
+        // Mask the API token value so it is hidden from the console output.
+        final boolean[] rbtCommandMask = new boolean[rbtCommand.size()];
+        rbtCommandMask[apiTokenIndex] = true;
 
-        // Generate a command mask to hide the API token from the console
-        // output.
-        final boolean[] rbtCommandMask = new boolean[rbtCommand.split(" ").length];
+        for (int i = 0; i < commands.size(); i++) {
+            final List<String> command = commands.get(i);
+            final Launcher.ProcStarter args = launcher.launch()
+                    .cmds(command)
+                    .stdout(listener)
+                    .pwd(workspace)
+                    .envs(env);
 
-        // Set the 4th entry's mask to true - this is the API token.
-        rbtCommandMask[3] = true;
+            // The patch command is the final entry and is the only one that
+            // carries a value to mask.
+            if (i == commands.size() - 1) {
+                args.masks(rbtCommandMask);
+            }
 
-        ArrayList<Launcher.ProcStarter> commands = new ArrayList<Launcher.ProcStarter>();
-        if (installRBTools) {
-            commands.add(launcher.launch().cmds(RBT_INSTALL.split(" ")));
-        }
-        commands.add(launcher.launch().cmds(rbtCommand.split(" ")).masks(rbtCommandMask));
-
-        for (Launcher.ProcStarter args : commands) {
-            // Run the command in the workspace
-            args.stdout(listener).pwd(workspace).envs(run.getEnvironment(listener));
             final Proc process = launcher.launch(args);
-
             final int result = process.join();
             if (result != 0) {
                 run.setResult(Result.FAILURE);
@@ -154,6 +192,34 @@ public class ReviewBoardSetup extends Builder implements SimpleBuildStep {
                     "See build");
         } catch (final ReviewBoardException e) {
             listener.error("Unable to notify Review Board of the build: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Returns whether the given rbt executable is available and runnable.
+     *
+     * This runs the executable with --version and checks for a successful
+     * exit code. A missing executable raises an IOException, which is treated
+     * as rbtools not being available.
+     * @param launcher Process launcher
+     * @param workspace Active workspace
+     * @param env Build environment
+     * @param rbtExecutable Path to or name of the rbt executable to probe
+     * @return true if the executable ran successfully
+     */
+    private boolean isRBToolsAvailable(
+            final Launcher launcher, final FilePath workspace, final EnvVars env, final String rbtExecutable)
+            throws InterruptedException {
+        try {
+            final Proc process = launcher.launch()
+                    .cmds(rbtExecutable, "--version")
+                    .pwd(workspace)
+                    .envs(env)
+                    .quiet(true)
+                    .start();
+            return process.join() == 0;
+        } catch (final IOException e) {
+            return false;
         }
     }
 

--- a/src/main/resources/org/reviewboard/rbjenkins/steps/ReviewBoardSetup/config.properties
+++ b/src/main/resources/org/reviewboard/rbjenkins/steps/ReviewBoardSetup/config.properties
@@ -1,3 +1,3 @@
 Description=This step will apply a patch from Review Board using RBTools. This step requires that the Review Board server details have been added in the "Configure System" admin page.
 DownloadOnly=Download the patch to patch.diff but do not apply. This allows you to add your own custom patch apply step in your build process.
-InstallRBTools=Install RBTools using `pip install --user rbtools`. Uncheck this if you've installed RBTools system-wide on the Jenkins server.
+InstallRBTools=Check whether RBTools is already available and, if not, install it into a virtualenv in the build workspace. Uncheck this if you've installed RBTools system-wide on the Jenkins server.

--- a/src/test/java/org/reviewboard/rbjenkins/steps/ReviewBoardSetupTest.java
+++ b/src/test/java/org/reviewboard/rbjenkins/steps/ReviewBoardSetupTest.java
@@ -3,7 +3,11 @@ package org.reviewboard.rbjenkins.steps;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.*;
+import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import jenkins.model.GlobalConfiguration;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -122,17 +126,18 @@ public class ReviewBoardSetupTest {
     }
 
     @Test
-    public void testBuildWithParameters() throws Exception {
+    public void testBuildWithParametersRBToolsAvailable() throws Exception {
         setupGlobalConfig();
         final String[] commands = {
-            "pip install --user rbtools",
+            "rbt --version",
             String.format(
                     "rbt patch --api-token %s --server %s " + "--diff-revision %s %s",
                     "UNKNOWN", REVIEWBOARD_URL, DIFF_REVISION, REVIEW_ID)
         };
 
         final PretendSlave slave = jenkins.createPretendSlave(procStarter -> {
-            // Check that we run the correct commands.
+            // When rbtools is already available the probe succeeds and we run
+            // the patch command directly, without creating a virtualenv.
             String command = String.join(" ", procStarter.cmds());
             assertTrue(ArrayUtils.contains(commands, command));
 
@@ -154,7 +159,7 @@ public class ReviewBoardSetupTest {
     public void testBuildWithParametersDownloadOnly() throws Exception {
         setupGlobalConfig();
         final String[] commands = {
-            "pip install --user rbtools",
+            "rbt --version",
             String.format(
                     "rbt patch --api-token %s --server %s " + "--diff-revision %s --write patch.diff %s",
                     "UNKNOWN", REVIEWBOARD_URL, DIFF_REVISION, REVIEW_ID)
@@ -177,6 +182,55 @@ public class ReviewBoardSetupTest {
 
         final FreeStyleBuild build = project.scheduleBuild2(0).get();
         jenkins.assertBuildStatus(Result.SUCCESS, build);
+    }
+
+    @Test
+    public void testBuildInstallsRBToolsInVirtualenv() throws Exception {
+        setupGlobalConfig();
+        final List<String> ranCommands = Collections.synchronizedList(new ArrayList<>());
+
+        final PretendSlave slave = jenkins.createPretendSlave(procStarter -> {
+            final String command = String.join(" ", procStarter.cmds());
+
+            // Probes for rbtools availability fail, so rbtools is installed
+            // into a virtualenv. All other commands succeed.
+            if (command.endsWith("--version")) {
+                return new FakeLauncher.FinishedProc(1);
+            }
+
+            ranCommands.add(command);
+            return new FakeLauncher.FinishedProc(0);
+        });
+
+        final FreeStyleProject project = jenkins.createFreeStyleProject();
+        addBuildParameters(project);
+
+        final ReviewBoardSetup builder = new ReviewBoardSetup(false, true);
+        project.getBuildersList().add(builder);
+        project.setAssignedNode(slave);
+
+        final FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.SUCCESS, build);
+
+        // A virtualenv is created, rbtools is installed into it, and the patch
+        // is applied using the rbt from the virtualenv. The virtualenv layout
+        // differs on Windows, so account for both the path separator and the
+        // "Scripts"/".exe" naming used there.
+        final boolean isUnix = File.separatorChar == '/';
+        final String binDir = isUnix ? "bin" : "Scripts";
+        final String exeSuffix = isUnix ? "" : ".exe";
+        final String exeSuffixRegex = isUnix ? "" : "\\.exe";
+
+        assertTrue(ranCommands.stream()
+                .map(c -> c.replace('\\', '/'))
+                .anyMatch(c -> c.matches("python3 -m venv .*\\.rbtools-venv")));
+        assertTrue(ranCommands.stream()
+                .map(c -> c.replace('\\', '/'))
+                .anyMatch(
+                        c -> c.matches(".*\\.rbtools-venv/" + binDir + "/pip" + exeSuffixRegex + " install rbtools")));
+        assertTrue(ranCommands.stream()
+                .map(c -> c.replace('\\', '/'))
+                .anyMatch(c -> c.contains(".rbtools-venv/" + binDir + "/rbt" + exeSuffix + " patch ")));
     }
 
     @Test


### PR DESCRIPTION
The setup step for Jenkins jobs was always running
`pip install --user rbtools` before applying a patch. If the workspace
within Jenkins already had a virtualenv this would fail entirely,
and even if not, it was wasteful to do it every time.

This now checks whether rbt is already on the PATH and only installs it
when needed. When it is missing, rbtools is installed into a virtualenv
in the workspace (reused across builds if present) rather than into the
user site directory.

The rbt patch invocation has also been reworked to pass the command as
an array instead of building a string and then splitting it on whitespace.

Testing Done:
Created a Jenkins testbed and verified that the first time a Review
Board job was triggered, it created a virtualenv and installed RBTools,
and thereafeter it reused it.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
